### PR TITLE
Fix win shares never updating due to fetch-level caching

### DIFF
--- a/app/bbref-api.server.ts
+++ b/app/bbref-api.server.ts
@@ -5,9 +5,9 @@ import { strict as assert } from 'assert';
 export const horfordUrl = 'https://www.basketball-reference.com/players/h/horfoal01.html';
 export const wembyUrl = 'https://www.basketball-reference.com/players/w/wembavi01.html'
 
-// Let fetch cache results - page is revalidated via daily cron job
+// Don't cache fetches - page-level caching handles revalidation via daily cron job
 const fetchParams: RequestInit = {
-    cache: 'force-cache'
+    cache: 'no-store'
 };
 
 type PopTip = 'Win Shares' | 'Games';


### PR DESCRIPTION
The fetch calls used `cache: 'force-cache'`, which makes Next.js's
Data Cache store the HTTP response indefinitely. When the daily cron
job calls `revalidatePath`, it only purges the Full Route Cache (the
rendered page), not the Data Cache. So the page re-rendered with the
same stale data every time.

Switching to `cache: 'no-store'` lets the page-level caching
(revalidate = false + cron) control freshness, and ensures fetches
actually hit Basketball-Reference when the page is regenerated.

https://claude.ai/code/session_01Uys4AyCMQ8fJ2fRMptKnkZ